### PR TITLE
Fix attachment positions (For 5.0.0+ only).

### DIFF
--- a/126r.lua
+++ b/126r.lua
@@ -18,6 +18,6 @@ definition.inventory_image = "car_126r_inventory.png"
 definition.wield_image = "car_126r_wield.png"
 definition.textures = {"car_126r.png"}
 -- player specific stuff
-definition.driver_attach_at = {x=0,y=10,z=-4}
+definition.driver_attach_at = {x=0,y=0,z=-4}
 
 vehicle_mash.register_vehicle("vehicle_mash:"..name, definition)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A merge of all the vehicles from:
 	- add a new line to init.lua to load the vehicle 'dofile(minetest.get_modpath("vehicle_mash").."/NAME_OF_VEHICLE.lua")'
 
 ## **Installation**
-- Unzip the archive, rename the folder to "vehicle_mash" (without the quotes) and place it in
+- Unzip the archive, rename the folder to "vehicle_mash" (**without the quotes**) and place it in
 ../minetest/mods/
 
 - GNU/Linux: If you use a system-wide installation place
@@ -31,7 +31,7 @@ the folder in worldmods/ in your world directory.
 
 
 For further information or help, see:
-http://wiki.minetest.net/Installing_Mods
+https://wiki.minetest.net/Installing_Mods
 
 ## **License**
 All licenses of previous works, of course, apply. (see credits below)
@@ -43,9 +43,9 @@ As far as the work I did... It's really just a fork of a fork of a fork of a for
 
 ## **Requirements**
 * "vehicle_mash" 2.1.0 for MT/MTG 5.0.0+.
-* "vehicle_mash" 2.0 for MT/MTG 0.4.16+ (may work on older versions).
+* "vehicle_mash" 2.0 for MT/MTG 0.4.12+ (may work on older versions).
 
-## **To Do**
+## **To-Do**
 - crafting
 
 ## **Changelog** 
@@ -56,7 +56,7 @@ v2.1 6/10/2019
 *	 Fix attachment positions for drivers/passengers on all vehicles.
 *	 Adds red, green, and yellow hovercrafts.
 *	 Use "mod.conf" for name, description and dependencies.
-*	 This version requieres MT/MTG 5.0.0 and/or above to work.
+*	 Support for MT/MTG 5.0.0+ (may not work with official dev-builds).
 	
 	
 v2.0 8/13/2016
@@ -68,7 +68,7 @@ v2.0 8/13/2016
 *	 various speed/braking/turning/acceleration tweaks
 *	 various collision box tweaks
 *	 various other tweaks I probably forgot about
-*	 last version supporting the 0.4-series.
+*	 last version supporting MT/MTG 0.4.12+.
 	
 		
 v1.4 5/19/2015
@@ -105,8 +105,7 @@ v1.0 4/24/2015
 
 
 ## **Bugs, suggestions and new features**
-Report bugs or suggest ideas by [creating an issue](https://github.com/blert2112/vehicle_mash/issues/new).
-
+Report bugs or suggest ideas by [creating an issue](https://github.com/blert2112/vehicle_mash/issues/new).      
 If you know how to fix an issue, consider opening a [pull request](https://github.com/blert2112/vehicle_mash/compare).
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A merge of all the vehicles from:
 - "Boats" by PilzAdam
 - "Hovercraft" by Stuart Jones
 
-- 27 vehicles currently.
+- 30 vehicles currently.
 - Certain vehicles can now carry passengers. Currently one passenger max.
 
 - Disable vehicles by commenting out it's 'dofile' line in init.lua

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-***Vehicle_mash***
-- version: 2.1.0
-- by blert2112
+# **Vehicle_mash**
+- Current version: 2.1.0
+- By blert2112
 
 A merge of all the vehicles from:
-- "Cars" by Radoslaw Slowik
-- "Mesecars" by paramat
-- "Car" by Esteban
-- "Boats" by PilzAdam
-- "Hovercraft" by Stuart Jones
+- "Cars" by Radoslaw Slowik.
+- "Mesecars" by paramat.
+- "Car" by Esteban.
+- "Boats" by PilzAdam.
+- "Hovercraft" by Stuart Jones.
 
 - 30 vehicles currently.
 - Certain vehicles can now carry passengers. Currently one passenger max.
@@ -19,21 +19,36 @@ A merge of all the vehicles from:
 	- change settings in the file you created to reflect the new vehicle
 	- add a new line to init.lua to load the vehicle 'dofile(minetest.get_modpath("vehicle_mash").."/NAME_OF_VEHICLE.lua")'
 
-***Installation***
-- rename folder to "vehicle_mash" if necessary
+## **Installation**
+- Unzip the archive, rename the folder to "vehicle_mash" (without the quotes) and place it in
+../minetest/mods/
 
-***License***
+- GNU/Linux: If you use a system-wide installation place
+it in ~/.minetest/mods/.
+
+- If you only want this to be used in a single world, place
+the folder in worldmods/ in your world directory.
+
+
+For further information or help, see:
+http://wiki.minetest.net/wiki/Installing_Mods
+
+## **License**
 All licenses of previous works, of course, apply. (see credits below)
 As far as the work I did... It's really just a fork of a fork of a fork of a fork, tossed it all into a blender and spun it on puree for a bit. Baked it for a while and set it on the counter to cool. What I mean is, make what you will of it, it matters not to me.
 
-***Dependencies***
-- default (included in Minetest Game)
+## **Dependencies**
+- default (included in minetest_game)
 - lib_mount
 
-***To Do***
+## **Requirements**
+* "vehicle_mash" 2.1.0 for MT/MTG 5.0.0+.
+* "vehicle_mash" 2.0 for MT/MTG 0.4.16+ (may work on older versions).
+
+## **To Do**
 - crafting
 
-***Changelog*** 
+## **Changelog** 
 
 
 v2.1 6/10/2019
@@ -89,7 +104,13 @@ v1.0 4/24/2015
 
 
 
-***CREDIT WHERE CREDIT IS DUE***
+## **Bugs, suggestions and new features**
+Report bugs or suggest ideas by [creating an issue](https://github.com/blert2112/vehicle_mash/issues/new).
+
+If you know how to fix an issue, consider opening a [pull request](https://github.com/blert2112/vehicle_mash/compare).
+
+
+## **Credit where credit is due**
 - F1 and 126R cars from: "Cars" by Radoslaw Slowik
 	- https://forum.minetest.net/viewtopic.php?f=9&t=8698
 	- License: Code WTFPL, modeles/textures CC BY-NC-ND 4.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-***Vehicles_mash***
-- version: 2.0
+***Vehicle_mash***
+- version: 2.1.0
 - by blert2112
 
 A merge of all the vehicles from:
@@ -7,9 +7,9 @@ A merge of all the vehicles from:
 - "Mesecars" by paramat
 - "Car" by Esteban
 - "Boats" by PilzAdam
-- "Hovercraft" by Stuart Jones (experimental and disabled by default)
+- "Hovercraft" by Stuart Jones
 
-- 26 vehicles currently (27 if you include the experimental hovercraft)
+- 27 vehicles currently.
 - Certain vehicles can now carry passengers. Currently one passenger max.
 
 - Disable vehicles by commenting out it's 'dofile' line in init.lua
@@ -27,39 +27,67 @@ All licenses of previous works, of course, apply. (see credits below)
 As far as the work I did... It's really just a fork of a fork of a fork of a fork, tossed it all into a blender and spun it on puree for a bit. Baked it for a while and set it on the counter to cool. What I mean is, make what you will of it, it matters not to me.
 
 ***Dependencies***
-- Default
+- default (included in Minetest Game)
 - lib_mount
 
 ***To Do***
-- complete the addition of the hovercraft
 - crafting
 
-***Change Log***
+***Changelog*** 
+
+
+v2.1 6/10/2019
+
+*	 Fix attachment positions for drivers/passengers on all vehicles.
+*	 Adds red, green, and yellow hovercrafts.
+*	 Use "mod.conf" for name, description and dependencies.
+*	 This version requieres MT/MTG 5.0.0 and/or above to work.
+	
+	
 v2.0 8/13/2016
-	- converted to use the lib_mount mod for "driving"
-	- enlarged F1 and 126r models x2.5
-	- added yellow Mesecar
-	- updated boat model from default boat mod
-	- various speed/braking/turning/acceleration tweaks
-	- various collision box tweaks
-	- various other tweaks I probably forgot about
+
+*	 converted to use the lib_mount mod for "driving"
+*	 enlarged F1 and 126r models x2.5
+*	 added yellow Mesecar
+*	 updated boat model from default boat mod
+*	 various speed/braking/turning/acceleration tweaks
+*	 various collision box tweaks
+*	 various other tweaks I probably forgot about
+*	 last version supporting the 0.4-series.
+	
+		
 v1.4 5/19/2015
-	- attach (one) passenger added
-	- reorganized vehicle definition file code and added some variables pertaining to passengers
-	- added a vehicle definition file template with comments
-	- cleaned up to remove code dulplication
+
+*	 attach (one) passenger added
+*	 reorganized vehicle definition file code and added some variables pertaining to passengers
+*	 added a vehicle definition file template with comments
+*	 cleaned up to remove code dulplication
+	
+	
 v1.3 5/5/2015
-	- player now sits forward in vehicles
-	- tweaked player sit positions
-	- tweaked collison boxes
-	- proper placement on_ground/in_water
-v1.2 5/1/2015 
-	- added boats
-	- changed name so  to not conflict with other mods
+
+*	 player now sits forward in vehicles
+*	 tweaked player sit positions
+*	 tweaked collison boxes
+*	 proper placement on_ground/in_water
+	
+	
+v1.2 5/1/2015
+
+*	 added boats
+*	 changed name so  to not conflict with other mods
+	
+	
 v1.1 4/25/2015
-	- car won't come to a complete stop (fixed)
+
+*	 car won't come to a complete stop (fixed)
+	
+	
 v1.0 4/24/2015
-	- first release
+
+*	first release
+
+
 
 ***CREDIT WHERE CREDIT IS DUE***
 - F1 and 126R cars from: "Cars" by Radoslaw Slowik

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ the folder in worldmods/ in your world directory.
 
 
 For further information or help, see:
-http://wiki.minetest.net/wiki/Installing_Mods
+http://wiki.minetest.net/Installing_Mods
 
 ## **License**
 All licenses of previous works, of course, apply. (see credits below)

--- a/description.txt
+++ b/description.txt
@@ -1,0 +1,1 @@
+Adds many types of vehicles.

--- a/f1.lua
+++ b/f1.lua
@@ -18,6 +18,6 @@ definition.inventory_image = "car_f1_inventory.png"
 definition.wield_image = "car_f1_wield.png"
 definition.textures = {"car_f1.png"}
 -- player specific stuff
-definition.driver_attach_at = {x=0,y=8,z=0}
+definition.driver_attach_at = {x=0,y=0,z=0}
 
 vehicle_mash.register_vehicle("vehicle_mash:"..name, definition)

--- a/hover_green.lua
+++ b/hover_green.lua
@@ -1,0 +1,11 @@
+
+local name = "hover_green"
+
+local definition = ...
+
+definition.description = "Green hovercraft"
+definition.inventory_image = "hovercraft_green_inv.png"
+definition.wield_image = "hovercraft_green_inv.png"
+definition.textures = {"hovercraft_green.png"}
+
+vehicle_mash.register_vehicle("vehicle_mash:"..name, definition)

--- a/hover_red.lua
+++ b/hover_red.lua
@@ -1,0 +1,11 @@
+
+local name = "hover_red"
+
+local definition = ...
+
+definition.description = "Red hovercraft"
+definition.inventory_image = "hovercraft_red_inv.png"
+definition.wield_image = "hovercraft_red_inv.png"
+definition.textures = {"hovercraft_red.png"}
+
+vehicle_mash.register_vehicle("vehicle_mash:"..name, definition)

--- a/hover_yellow.lua
+++ b/hover_yellow.lua
@@ -1,0 +1,11 @@
+
+local name = "hover_yellow"
+
+local definition = ...
+
+definition.description = "Yellow hovercraft"
+definition.inventory_image = "hovercraft_yellow_inv.png"
+definition.wield_image = "hovercraft_yellow_inv.png"
+definition.textures = {"hovercraft_yellow.png"}
+
+vehicle_mash.register_vehicle("vehicle_mash:"..name, definition)

--- a/init.lua
+++ b/init.lua
@@ -200,6 +200,9 @@ local hover_def = {
 -- vehicle specific values in the following files
 -- you can override any common values from here
 loadfile(mpath.."/hover_blue.lua")(table.copy(hover_def))
+loadfile(mpath.."/hover_green.lua")(table.copy(hover_def))
+loadfile(mpath.."/hover_red.lua")(table.copy(hover_def))
+loadfile(mpath.."/hover_yellow.lua")(table.copy(hover_def))
 
 -- free unneeded global(s)
 core.after(10, function()

--- a/init.lua
+++ b/init.lua
@@ -60,10 +60,10 @@ local car01_def = {
 	onplace_position_adj = -0.45,
 	--player specific stuff
 	player_rotation = {x=0,y=90,z=0},
-	driver_attach_at = {x=3.5,y=12,z=3.5},
+	driver_attach_at = {x=3.5,y=3.7,z=3.5},
 	driver_eye_offset = {x=-4, y=0, z=0},
 	number_of_passengers = 1,
-	passenger_attach_at = {x=3.5,y=12,z=-3.5},
+	passenger_attach_at = {x=3.5,y=3.7,z=-3.5},
 	passenger_eye_offset = {x=4, y=0, z=0},
 	--drop and recipe
 	drop_on_destroy = "",
@@ -114,7 +114,7 @@ local mesecar_def = {
 	onplace_position_adj = 0.25,
 	--player specific stuff
 	player_rotation = {x=0,y=0,z=0},
-	driver_attach_at = {x=0,y=2,z=0},
+	driver_attach_at = {x=0,y=0,z=-2.0},
 	driver_eye_offset = {x=0, y=0, z=0},
 	number_of_passengers = 0,
 	passenger_attach_at = {x=0,y=0,z=0},
@@ -153,7 +153,7 @@ local boat_def = {
 	textures = {"default_wood.png"},
 	--player specific stuff
 	player_rotation = {x=0, y=0, z=0},
-	driver_attach_at = {x=0,y=11,z=-3},
+	driver_attach_at = {x=0.5,y=1,z=-3},
 	driver_eye_offset = {x=0, y=0, z=0},
 	number_of_passengers = 0,
 	passenger_attach_at = {x=0,y=0,z=0},
@@ -187,7 +187,7 @@ local hover_def = {
 	onplace_position_adj = -0.25,
 	--player specific stuff
 	player_rotation = {x=0,y=90,z=0},
-	driver_attach_at = {x=-2,y=16.5,z=0},
+	driver_attach_at = {x=-2,y=6.3,z=0},
 	driver_eye_offset = {x=0, y=0, z=0},
 	number_of_passengers = 0,
 	passenger_attach_at = {x=0,y=0,z=0},

--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,3 @@
+name = vehicle_mash
+depends = default, lib_mount
+description = Adds many types of vehicles.


### PR DESCRIPTION
This Pull request fixes attachment positions for drivers/passengers on all vehicles.
Note that this Pull request won't work correctly for the 0.4-series. 
**The PR blert2112/lib_mount#1 must be merged in order to make "vehicle_mash" to work correctly, smooth & fast, after this Pull request is merged.**

Tested with MT/MTG 5.0.1-stable and works fine.
If I have made any error/typo, please let me know, we can work together to fix it. 😉